### PR TITLE
Overwrite callback_url to ignore query string params

### DIFF
--- a/lib/omniauth/strategies/office365.rb
+++ b/lib/omniauth/strategies/office365.rb
@@ -47,6 +47,10 @@ module OmniAuth
       OFFICE365_JWT_ORGANIZATION_IDENTIFER = 'tid'.freeze
       OFFICE365_JWT_USER_PRINCIPAL_NAME = 'upn'.freeze
 
+      def callback_url
+        options[:redirect_uri] || (full_host + script_name + callback_path)
+      end
+
       def decoded_jwt_token
         JWT.decode(access_token.token, nil, false)
       rescue JWT::DecodeError


### PR DESCRIPTION
* Per the work of @brandonhilkert [here](https://github.com/murbanski/omniauth-microsoft-office365/pull/2) and the work of @nickmerwin [here](https://github.com/simi/omniauth-office365/pull/8) this change fixes the issue of having an incorrect redirect_uri error appear when trying to authorize a user