### PR TITLE
Chore/update omniauth oauth2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,7 +33,7 @@ Style/BracesAroundHashParameters:
 
 # Indentation of `when`.
 Style/CaseIndentation:
-  IndentWhenRelativeTo: end
+  EnforcedStyle: end
   SupportedStyles:
     - case
     - end
@@ -156,6 +156,10 @@ Metrics/MethodLength:
 
 Metrics/LineLength:
   Max: 120
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
 
 ##################### Lint ################################
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.5.1
   - jruby-18mode
   - jruby-19mode
   - jruby-head

--- a/Rakefile
+++ b/Rakefile
@@ -11,8 +11,8 @@ begin
   RuboCop::RakeTask.new
 rescue LoadError
   task :rubocop do
-    $stderr.puts 'RuboCop is disabled'
+    warn 'RuboCop is disabled'
   end
 end
 
-task :default => [:spec, :rubocop]
+task :default => %i[spec rubocop]

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'sinatra'
 gem 'omniauth-office365', :path => '../'
+gem 'sinatra'

--- a/lib/omniauth-office365.rb
+++ b/lib/omniauth-office365.rb
@@ -1,3 +1,4 @@
 # rubocop:disable Style/FileName
 require 'omniauth-office365/version'
 require 'omniauth/strategies/office365'
+# rubocop:enable Style/FileName

--- a/lib/omniauth-office365/version.rb
+++ b/lib/omniauth-office365/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Office365
-    VERSION = '1.0.0'.freeze
+    VERSION = '1.1.0'.freeze
   end
 end

--- a/lib/omniauth/strategies/office365.rb
+++ b/lib/omniauth/strategies/office365.rb
@@ -38,6 +38,14 @@ module OmniAuth
       def raw_info
         @raw_info ||= access_token.get('api/v2.0/me').parsed
       end
+
+      private
+
+      # Overriding this method provided by OmniAuth::Strategies - we don't want the querystring appended to the callback_url
+      # See https://github.com/omniauth/omniauth-oauth2/issues/81
+      def callback_url
+        full_host + script_name + callback_path
+      end
     end
   end
 end

--- a/lib/omniauth/strategies/office365.rb
+++ b/lib/omniauth/strategies/office365.rb
@@ -41,7 +41,8 @@ module OmniAuth
 
       private
 
-      # Overriding this method provided by OmniAuth::Strategies - we don't want the querystring appended to the callback_url
+      # Overriding this method provided by OmniAuth::Strategies
+      #   we don't want the querystring appended to the callback_url
       # See https://github.com/omniauth/omniauth-oauth2/issues/81
       def callback_url
         full_host + script_name + callback_path

--- a/omniauth-office365.gemspec
+++ b/omniauth-office365.gemspec
@@ -1,4 +1,4 @@
-require File.expand_path('../lib/omniauth-office365/version', __FILE__)
+require File.expand_path('lib/omniauth-office365/version', __dir__)
 
 Gem::Specification.new do |gem|
   gem.authors       = 'Jeff Carbonella'
@@ -6,13 +6,13 @@ Gem::Specification.new do |gem|
   gem.description   = 'OmniAuth OAuth2 strategy for the Office365 v2.0 REST API.'
   gem.summary       = gem.description
   gem.homepage      = 'https://github.com/jcarbo/omniauth-office365'
-  gem.licenses      = %w(MIT)
+  gem.licenses      = %w[MIT]
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").collect { |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.name          = 'omniauth-office365'
-  gem.require_paths = %w(lib)
+  gem.require_paths = %w[lib]
   gem.version       = OmniAuth::Office365::VERSION
 
   gem.add_dependency 'omniauth-oauth2', '~> 1.6.0'

--- a/omniauth-office365.gemspec
+++ b/omniauth-office365.gemspec
@@ -15,8 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w(lib)
   gem.version       = OmniAuth::Office365::VERSION
 
-  # Lock at 1.3.x due to https://github.com/intridea/omniauth-oauth2/issues/81
-  gem.add_dependency 'omniauth-oauth2', '~> 1.3.1'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.6.0'
 
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'rake'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-$LOAD_PATH.unshift File.expand_path('..', __FILE__)
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path(__dir__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 require 'rspec'
 require 'rack/test'


### PR DESCRIPTION
The main reason for updating this gem is to be able to bump omniauth-google-oauth2 to 0.6.0 which removes hitting the deprecated Google+ APIs

In order to do this, we needed to bump the lock version of `omniauth-oauth2` to `1.6.0`

To fix the issues we were band-aiding with version 1.3.1 of `omniauth-oauth2` is explained below:

Override callback_url method provided by OmniAuth::Strategies

`omniauth-oauth2` 1.4.0 removed overriding this method itself - this
caused an issue where the callback_url was not exactly matching what the
provider (microsoft) expects and returning an error during the oauth
authentication process.

The `omniauth` gem appends any `querystring` value to the callback_url
which is sort of OAuth 2.0 spec compliant but the spec is vague so
having the querystring in the callback url isn't hard defined - hence
the differences between providers.

In any case, microsoft wants no querystring in the callback url so we
override the method here to remove the querystring